### PR TITLE
Disabled default-features in async-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,7 @@ license = "MIT"
 repository = "https://github.com/alexliesenfeld/async-object-pool"
 
 [dependencies]
+async-std = { version = "1.13.0", features = ["unstable"], default-features = false }
+
+[dev-dependencies]
 async-std = { version = "1.13.0", features = ["unstable"] }


### PR DESCRIPTION
Disable the default-features of async-std. This will speed up compilation by removing the extra dependency.

In my environment, the compilation time was reduced by about 2 seconds.

<details>
<summary>The screenshot from `cargo build -r --timings'</summary>

Enabled default-features.

![image](https://github.com/user-attachments/assets/67e65ae8-0398-42b0-96aa-639a49e88f98)

Disabled default-features.

![image](https://github.com/user-attachments/assets/c87a5e9b-40ce-4c91-ab84-83ca9c084338)
</details>

Thanks!
